### PR TITLE
add meaning for "MIS" acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ######The Space Based Manufacturing Specifications Manual is designed to establish a simple and consistent set of standards for plug-and-play design and code of space-based manufacturing technology.
 
-Each of these aspects contains an assortment of interface descriptions that are open to the community to develop new hardware and software upon. We invite you to read through the interface releases and standards. These interfaces are currently in use by the MIS additive manufacturing facility (AMF). These interfaces are the cornerstone of our plug-and-play technologies, which means that as new technologies are developed by the community they can be infused into current and future space
+Each of these aspects contains an assortment of interface descriptions that are open to the community to develop new hardware and software upon. We invite you to read through the interface releases and standards. These interfaces are currently in use by the Made In Space (MIS) Additive Manufacturing Facility (AMF). These interfaces are the cornerstone of our plug-and-play technologies, which means that as new technologies are developed by the community they can be infused into current and future space
 manufacturing platforms.
 
 As an Open Published format, the contents will be continually evolving. We welcome your support in future iterations. The current release makes available the interface standards for the core aspects for additive manufacturing techniques in space. These include; Materials Handling, Materials Processing, and the Manufacturing Environment.


### PR DESCRIPTION
The MIS acronym is used in the README without adding context. Here it is written out.